### PR TITLE
Remove placeholder assets and adjust bobber frame path

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -54,9 +54,9 @@ export const ASSETS = {
   },
   // 5‑second hero intro clips
   intros: {
-    fertle: 'assets/intros/intro_fertle.mp4',
-    fygar:  'assets/intros/intro_fygar.mp4',
-    // …
+    fertle: 'assets/intros/char_fertle.mp4',
+    fygar:  'assets/intros/char_fygar.mp4',
+    // additional intros can be placed in assets/intros/char_<id>.mp4
   },
   // UI icons
   ui: {

--- a/src/data/enemies/bobber.js
+++ b/src/data/enemies/bobber.js
@@ -3,7 +3,7 @@
 //  The “bobber” ground-patrol enemy used in sample Level 01.
 //  Put the four PNGs in  assets/enemies/
 //
-//    enemy_bobber_idle.png
+//    enemy_bobber_idel.png
 //    enemy_bobber_walk1.png
 //    enemy_bobber_walk2.png
 //    enemy_bobber_attack.png   ← optional (not used yet)
@@ -14,7 +14,7 @@ export default {
   id: 'bobber',
 
   frames: {
-    idle:   'enemy_bobber_idle.png',
+    idle:   'enemy_bobber_idel.png',
     walk1:  'enemy_bobber_walk1.png',
     walk2:  'enemy_bobber_walk2.png',
     attack: 'enemy_bobber_attack.png'   // (leave out or rename if you’ve only drawn three frames)


### PR DESCRIPTION
## Summary
- revert placeholder audio and life icon
- restore original enemy filename and update bobber data
- keep corrected hero intro paths

## Testing
- `ls -l assets/enemies | head`
- `ls -l assets | head`


------
https://chatgpt.com/codex/tasks/task_e_68629cbb7cb4832687c1fc577d973de5