### PR TITLE
Add intro music and lighten overlay

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -89,7 +89,7 @@ video#introVideo {
   position:absolute; inset:0;
   display:flex; flex-direction:column; justify-content:flex-end;
   padding:2rem; box-sizing:border-box;
-  background:rgba(0,0,0,0.65); /* overlay without blur so video stays sharp */
+  background:rgba(0,0,0,0.3); /* lighter overlay so video not overly dim */
   font-size:1.2rem; line-height:1.45; text-align:center;
 }
 #storyText { margin:0 auto 1.5rem; max-width:740px; }

--- a/src/states/intro-story.js
+++ b/src/states/intro-story.js
@@ -15,12 +15,26 @@ export default class IntroStoryState extends StateBase {
     this.videoEl.src = 'assets/video/king_loop.mp4';      // add this file
     this.videoEl.loop = true;                             // keep playing
 
+    // background music
+    this.bgm = new Audio('assets/audio/bgm_intro.mp3');
+    this.bgm.volume = 0.4;
+    this.bgm.loop = true;
+
     // show intro elements
     this.videoEl.style.display = 'block';
     this.canvas.style.backgroundImage = "url('assets/backgrounds/intro_bg.png')";
     this.canvas.style.backgroundSize = 'cover';
 
     await this.videoEl.play().catch(()=>{});              // autoplay muted
+
+    // attempt to autoplay bgm; may require first user gesture
+    this.bgm.play().catch(() => {
+      const resume = () => {
+        this.bgm.play().catch(()=>{});
+        window.removeEventListener('pointerdown', resume);
+      };
+      window.addEventListener('pointerdown', resume);
+    });
 
     /* ---------- Text pages ------ */
     this.pages = STORY_PAGES;    // imported below
@@ -75,6 +89,10 @@ export default class IntroStoryState extends StateBase {
     this.videoEl.pause();
     this.videoEl.loop = false;
     this.videoEl.style.display = 'none';
+    if (this.bgm) {
+      this.bgm.pause();
+      this.bgm.currentTime = 0;
+    }
     this.canvas.style.backgroundImage = 'none';
     this.canvas.style.backgroundSize = '';
     this.nextBtn.removeEventListener('click', this.onClick);
@@ -89,6 +107,10 @@ export default class IntroStoryState extends StateBase {
     this.videoEl.pause();
     this.videoEl.loop = false;
     this.videoEl.style.display = 'none';
+    if (this.bgm) {
+      this.bgm.pause();
+      this.bgm.currentTime = 0;
+    }
     this.canvas.style.backgroundImage = 'none';
     this.canvas.style.backgroundSize = '';
   }


### PR DESCRIPTION
## Summary
- lighten the story overlay so intro video isn't dim
- add looping intro background music at 40% volume that stops once you begin the adventure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68692e00d4688326aa6b4251ca952369